### PR TITLE
Student groups: my groups - happy path.

### DIFF
--- a/reporting/sql/V201702061486427077__initial_ddl.sql
+++ b/reporting/sql/V201702061486427077__initial_ddl.sql
@@ -230,6 +230,8 @@ CREATE TABLE IF NOT EXISTS user_student_group (
   CONSTRAINT fk__user_student_group__student_group FOREIGN KEY (student_group_id) REFERENCES student_group(id)
 );
 
+ALTER TABLE user_student_group ADD INDEX idx__user_student_group__user (user_login);
+
 /** IAB exams **/
 
 CREATE TABLE IF NOT EXISTS iab_exam_student (


### PR DESCRIPTION
This is to support:
https://confluence.fairwaytech.com/display/SWF/0.1+My+Groups+Widget

Example SQL: 
```
SELECT
  g.id,
  g.name,
  g.school_id,
  sch.name,
  s.id,
  s.name,
  CASE (SELECT 1
        FROM dual
        WHERE exists(
            SELECT gm.student_id
            FROM student_group_membership gm
              JOIN iab_exam_student iab ON iab.student_id = gm.student_id
              JOIN school sch ON sch.id = iab.school_id
            --the below will be constructed from the user's tenancy chain
            WHERE (sch.id IN (-1) OR district_id IN (-1) OR 1 = 1) AND gm.student_group_id = g.id
            UNION ALL
            SELECT gm.student_id
            FROM student_group_membership gm
              JOIN exam_student e ON e.student_id = gm.student_id
              JOIN school sch ON sch.id = e.school_id
            WHERE (sch.id IN (-1) OR district_id IN (-1) OR 1 = 1) AND gm.student_group_id = g.id
        ))
  WHEN 1
    THEN 1
  ELSE 0
  END AS has_students
FROM user_student_group ug
  JOIN student_group g ON ug.student_group_id = g.id
  JOIN school sch ON sch.id = g.school_id
  JOIN subject s ON s.id = g.subject_id
WHERE ug.user_login = 'dwtest@example.com';
```
![groups](https://cloud.githubusercontent.com/assets/16457484/25153619/05b79932-2442-11e7-81ef-deb21e5f50d2.png)


**That is one nasty query. We may consider reworking the UI and instead of disabling the link do something when a user clicks the link. But this shows the idea of what needs to be done, I think.**