### PR TITLE
Add indexes to reporting

### DIFF
--- a/reporting/sql/V201706011496359500__added_indexes_to_exam_ddl.sql
+++ b/reporting/sql/V201706011496359500__added_indexes_to_exam_ddl.sql
@@ -1,0 +1,12 @@
+/**
+* Add a few indexes to exam
+**/
+
+USE ${schemaName};
+
+CREATE INDEX idx__exam__asmt_school_year ON exam (asmt_id, school_id, school_year);
+CREATE INDEX idx__exam__school_grade ON exam (school_id, grade_id);
+
+-- When adding an index that has the first column from a FOREIGN KEY CONSTRAINT, mySQL drops the FK index
+-- This index seems to still improve performance of some queries, so I am adding it back.
+CREATE INDEX fk__exam__school ON exam (school_id);


### PR DESCRIPTION
@malaffoon, there is no easy way in mySQL to say ```CREATE INDEX IF NOT EXISTS```. I hope this will migrate on AWS since I played with indexes there. If not, I will have to find a better way.