### PR TITLE
DWR-469 a few more changes and the run time stats

### DIFF
--- a/warehouse/sql/group_admin_hack.sql
+++ b/warehouse/sql/group_admin_hack.sql
@@ -20,9 +20,9 @@ CREATE TABLE IF NOT EXISTS student_group_load (
   import_id         BIGINT
 );
 
-alter table student_group_load add  INDEX idx__student_group_load__name_batch_id (name, batch_id);
-alter table student_group_load add  INDEX idx__student_group_load__student_id_batch_id (student_id, batch_id);
-alter table student_group_load add  INDEX idx__student_group_load__student_ssid_batch_id (student_ssid, batch_id);
+# alter table student_group_load add  INDEX idx__student_group_load__name_batch_id (name, batch_id);
+# alter table student_group_load add  INDEX idx__student_group_load__student_id_batch_id (student_id, batch_id);
+# alter table student_group_load add  INDEX idx__student_group_load__student_ssid_batch_id (student_ssid, batch_id);
 
 # # TODO: add creator
 DROP TABLE IF EXISTS batch_group_load;
@@ -51,9 +51,8 @@ CREATE TABLE IF NOT EXISTS student_group_load_import (
   ref_type  TINYINT, -- 1 = new student, 0 = restore deleted student, 2 = new groups, 3 = modified groups membership, 4 = modified user, 5 = modified group
   UNIQUE INDEX idx__student_group_load_import__batch_ref (batch_id, ref)
 );
-alter table student_group_load_import add  INDEX idx__student_group_load_import__school_batch (school_id, batch_id);
-alter table student_group_load_import add  INDEX idx__student_group_load_import__school_import_batch (school_id, import_id, batch_id);
-
+# alter table student_group_load_import add  INDEX idx__student_group_load_import__school_batch (school_id, batch_id);
+# alter table student_group_load_import add  INDEX idx__student_group_load_import__school_import_batch (school_id, import_id, batch_id);
 
 
 ########################################### start batch processing ###########################################
@@ -170,6 +169,7 @@ UPDATE student_group_load sgl
 SET group_id = sg.id
 WHERE batch_id = 33;
 INSERT INTO batch_group_load_progress (batch_id, message) VALUE (33, 'update group id in the load table, first time');
+
 
 # Considerations:
 # - migrate will be suspended if we have import ids in state 0 for a long time

--- a/warehouse/sql/group_admin_hack.sql
+++ b/warehouse/sql/group_admin_hack.sql
@@ -141,7 +141,7 @@ FROM (
          subject_id
        FROM student_group_load sgl
        WHERE batch_id = 33) AS count;
-INSERT INTO batch_group_load_progress (batch_id, message) VALUE (33, 'count DISTINCT with subject');
+INSERT INTO batch_group_load_progress (batch_id, message) VALUE (33, 'count DISTINCT school_id, school_year, name, subject_id');
 
 SELECT count(*)
 FROM (
@@ -151,7 +151,7 @@ FROM (
          name
        FROM student_group_load sgl
        WHERE batch_id = 33) AS count;
-INSERT INTO batch_group_load_progress (batch_id, message) VALUE (33, 'count DISTINCT');
+INSERT INTO batch_group_load_progress (batch_id, message) VALUE (33, 'count DISTINCT school_id, school_year, name');
 
 # TODO: consider validating the size of the file and rejecting if larger than 1 mil?
 
@@ -291,6 +291,7 @@ INSERT INTO batch_group_load_progress (batch_id, message) VALUE (33, 'update stu
 UPDATE student_group_load sgl
 SET import_id = NULL
 WHERE batch_id = 33;
+INSERT INTO batch_group_load_progress (batch_id, message) VALUE (33, 'reset import ids to null');
 
 # We want to only migrate groups that have changed
 # that means we want to update the import id only on those groups, hence we need to determine the delta
@@ -312,6 +313,8 @@ INSERT IGNORE INTO student_group_load_import (batch_id, school_id, ref, ref_type
     2
   FROM student_group_load sgl
   WHERE sgl.group_id IS NULL and batch_id = 33;
+INSERT INTO batch_group_load_progress (batch_id, message) VALUE (33, 'load student_group_load_import with ids of groups, ref type = 2');
+
 
 INSERT IGNORE INTO student_group_load_import (batch_id, school_id, ref, ref_type)
 
@@ -342,6 +345,9 @@ INSERT IGNORE INTO student_group_load_import (batch_id, school_id, ref, ref_type
     ) AS existing
       ON existing.student_group_id = loading.group_id
   WHERE existing.students <> loading.students;
+INSERT INTO batch_group_load_progress (batch_id, message) VALUE (33, 'load student_group_load_import with ids of groups, ref type = 3');
+
+
 
 INSERT IGNORE INTO student_group_load_import (batch_id, school_id, ref, ref_type)
 
@@ -373,6 +379,7 @@ INSERT IGNORE INTO student_group_load_import (batch_id, school_id, ref, ref_type
     ) AS existing
       ON existing.student_group_id = loading.group_id
   WHERE existing.users <> loading.users;
+INSERT INTO batch_group_load_progress (batch_id, message) VALUE (33, 'load student_group_load_import with ids of groups, ref type = 4');
 
 INSERT IGNORE INTO student_group_load_import (batch_id, school_id, ref, ref_type)
 #schools with the existing groups that have changes
@@ -384,7 +391,7 @@ INSERT IGNORE INTO student_group_load_import (batch_id, school_id, ref, ref_type
   FROM student_group_load sgl
     JOIN student_group sg ON sg.id = sgl.group_id
   WHERE ifnull(sg.subject_id, -1) != sgl.subject_id;
-INSERT INTO batch_group_load_progress (batch_id, message) VALUE (33, 'generated cached import ids for the groups in the batch, one per school');
+INSERT INTO batch_group_load_progress (batch_id, message) VALUE (33, 'load student_group_load_import with ids of groups, ref type = 5');
 
 # generate a new set of import ids for the groups
 INSERT INTO import (status, content, contentType, digest, batch)


### PR DESCRIPTION
Since people are now reviewing it, I wanted to share the changes.
Ignore a change from 100 to 33. It is not just I like 33 more, but it is more unique for copy/replace and I was doing it in my local testing a lot.

I will note all other changes.

Here are the run time stats for two opposite test cases: load a CSV with about 800,000 rows, all new student, groups, and then re-running the same file again:

message | time in seconds - first run | same with no indexes | second run | second run - no indexes
-- | -- | -- | -- | --
start |   |   |   |  
load csv | 34 | 14 | 34 | 13
update school and subject | 36 | 36 | 36 | 36
validate school | 1 | 1 | 1 | 1
validate subject | 1 | 1 | 1 | 1
count DISTINCT school_id, school_year,   name, subject_id | 4 | 7 | 4 | 7
count DISTINCT school_id, school_year,   name | 2 | 2 | 2 | 2
update student id in the load table,   first time | 47 | 42 | 113 | 67
update group id in the load table, first   time | 5 | 1 | 31 | 21
load student_group_load_import with ids   for students | 26 | 28 | 12 | 12
create import ids for students | 1 | 1 | 0 | 0
update student_group_load_import with   import ids for students | 24 | 21 | 0 | 0
updated student_group_load import id, one   per school | 24 | 25 | 0 | 0
insert new students into warehouse | 18 | 17 | 1 | 1
updated deleted students in warehouse | 1 | 1 | 1 | 1
update import id to migrate students | 2 | 2 | 0 | 0
update student id in the load table | 23 | 16 | 0 | 1
reset import ids to null | 13 | 12 | 8 | 7
load student_group_load_import with ids   of groups, ref type = 2 | 53 | 48 | 1 | 1
load student_group_load_import with ids   of groups, ref type = 3 | 12 | 14 | 12 | 13
load student_group_load_import with ids   of groups, ref type = 4 | 0 | 0 | 7 | 7
load student_group_load_import with ids   of groups, ref type = 5 | 1 | 1 | 1 | 1
generated import ids for the groups in   the batch, one per school | 1 | 1 | 0 | 0
update student_group_load_import with   import ids for students | 8 | 8 | 0 | 0
updated import id for groups, one per   school | 21 | 21 | 0 | 0
moved groups over | 52 | 53 | 3 | 3
update group id in the load table after   creating new groups | 21 | 20 | 8 | 1
update import id to migrate students | 45 | 45 | 10 | 11
  | 476 | 438 | 286 | 207



Things left to do within this JIRA:
- [x] Approach with moving groups/students/users into its own table (Mark's idea that I like). -**did not seem to help, unfortunately**
- [x] Play with indexes - I will timebox it to a few hours.
- [x]  Rewrite the query with GROUP_CONCAT to use the other approach mentioned in the code. - **I gave it a try, but it was slower**
- [ ] Research loading CSV: empty vs null and the end of line chars. I may create a new JIRA for this one since I do not think it is on a critical path. 
- [ ]  Restore AWS dev. to a clean state. A few things did not go right and I need to clean it up.
