### PR TITLE
DWR-694 Add report generation table

### DIFF
--- a/reporting/sql/V201708011501635215__add_report_generation.sql
+++ b/reporting/sql/V201708011501635215__add_report_generation.sql
@@ -2,15 +2,14 @@
 
 USE ${schemaName};
 
-CREATE TABLE IF NOT EXISTS report_generation (
+CREATE TABLE IF NOT EXISTS user_report (
   id bigint(20) NOT NULL AUTO_INCREMENT PRIMARY KEY,
-  user_login varchar(255) COLLATE utf8_unicode_ci NOT NULL,
+  user_login varchar(255) NOT NULL,
   job_execution_id bigint(20),
   status tinyint(4) NOT NULL,
   report_resource_uri varchar(255),
   label varchar(255) NOT NULL,
   report_request text NOT NULL,
   created TIMESTAMP(6) NOT NULL,
-  KEY idx__report_generation__user_login_label (user_login, label),
-  KEY idx__report_generation__created (created)
+  INDEX idx__report_generation__user_login (user_login)
 );

--- a/reporting/sql/V201708011501635215__add_report_generation.sql
+++ b/reporting/sql/V201708011501635215__add_report_generation.sql
@@ -1,0 +1,16 @@
+-- Add a report_generation table to track user report requests
+
+USE ${schemaName};
+
+CREATE TABLE IF NOT EXISTS report_generation (
+  id bigint(20) NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  user_login varchar(255) COLLATE utf8_unicode_ci NOT NULL,
+  job_execution_id bigint(20),
+  status tinyint(4) NOT NULL,
+  report_resource_uri varchar(255),
+  label varchar(255) NOT NULL,
+  report_request text NOT NULL,
+  created TIMESTAMP(6) NOT NULL,
+  KEY idx__report_generation__user_login_label (user_login, label),
+  KEY idx__report_generation__created (created)
+);


### PR DESCRIPTION
Add the report_generation table to the reporting schema.

I waffled a bit on the name: "report" sounded too generic inside a "reporting" schema.  Thoughts?