### PR TITLE
remove replay_id

### DIFF
--- a/warehouse/sql/V201708081502210140__remove_replay_id.sql
+++ b/warehouse/sql/V201708081502210140__remove_replay_id.sql
@@ -1,0 +1,8 @@
+-- remove the replay_id as it is no longer needed
+--
+-- delete any import records with replay_id set, since they are represented by another record
+
+USE ${schemaName};
+
+DELETE FROM import WHERE replay_id IS NOT NULL;
+ALTER TABLE import DROP COLUMN replay_id;


### PR DESCRIPTION
With the changes to migrate, making it timestamp-based, there is no longer a need to copy import records and set the replay_id on the originals.