### PR TITLE
Record original filename when uploading a Group definition CSV.

### DIFF
--- a/warehouse/sql/V201708171503010368__add_student_group_batch_filename.sql
+++ b/warehouse/sql/V201708171503010368__add_student_group_batch_filename.sql
@@ -1,0 +1,5 @@
+-- Modify upload_student_group_batch to include uploaded file name
+
+USE ${schemaName};
+
+ALTER TABLE upload_student_group_batch ADD filename VARCHAR(200);

--- a/warehouse/sql/V201708171503010368__add_student_group_batch_filename.sql
+++ b/warehouse/sql/V201708171503010368__add_student_group_batch_filename.sql
@@ -2,4 +2,4 @@
 
 USE ${schemaName};
 
-ALTER TABLE upload_student_group_batch ADD filename VARCHAR(200);
+ALTER TABLE upload_student_group_batch ADD filename VARCHAR(255);


### PR DESCRIPTION
There is a request from the UI team to display the original filename in the upload results table.  This PR adds a column to the upload_student_group_batch table representing the upload so that we have a place to store it.