### PR TITLE
Update unique index on upload_student_group_import to allow an import

### DIFF
--- a/warehouse/sql/V201708211503357022__update_group_processing_indexes.sql
+++ b/warehouse/sql/V201708211503357022__update_group_processing_indexes.sql
@@ -1,4 +1,5 @@
 -- Update the unique index to consider the school id
+-- Modify the upload student_id column to match the student.id type
 
 USE ${schemaName};
 
@@ -7,3 +8,6 @@ ALTER TABLE upload_student_group_import
 
 ALTER TABLE upload_student_group_import
   ADD UNIQUE INDEX idx__upload_student_group_import__batch_ref_school (batch_id, ref_type, school_id);
+
+ALTER TABLE upload_student_group
+  MODIFY COLUMN student_id int(11);

--- a/warehouse/sql/V201708211503357022__update_group_processing_indexes.sql
+++ b/warehouse/sql/V201708211503357022__update_group_processing_indexes.sql
@@ -1,0 +1,9 @@
+-- Update the unique index to consider the school id
+
+USE ${schemaName};
+
+ALTER TABLE upload_student_group_import
+  DROP INDEX idx__upload_student_group_import__batch_ref;
+
+ALTER TABLE upload_student_group_import
+  ADD UNIQUE INDEX idx__upload_student_group_import__batch_ref_school (batch_id, ref_type, school_id);


### PR DESCRIPTION
per batch, per ref_type, per school

While writing integration tests for the user import phase of group ingest I found that only users from a single school were being imported.  This patch updates the unique index to allow an import per batch, per ref_type (insert/un-delete), per school.