### PR TITLE
patch unknown targets

### DIFF
--- a/reporting/sql/V1_0_0_4__fix_targets.sql
+++ b/reporting/sql/V1_0_0_4__fix_targets.sql
@@ -1,0 +1,14 @@
+-- fixes two errant targets
+--
+-- instead of relying on migrate, this just patches in the changes
+-- (when consolidating scripts that means you can just ignore this file)
+
+USE ${schemaName};
+
+DELETE FROM target WHERE code = 'Q' AND description = 'Statistics and Probability: Summarize, represent, and interpret data on a single count or measurement variable.';
+DELETE FROM target WHERE code = 'P' AND description = 'Geometry: Define trigonometric ratios and solve problems involving right triangles.';
+
+UPDATE target SET description = 'Statistics and Probability: Summarize, represent, and interpret data on a single count or measurement variable.'
+  WHERE code = 'P' AND description = 'UNKNOWN';
+UPDATE target SET description = 'Geometry: Define trigonometric ratios and solve problems involving right triangles.'
+  WHERE code = 'O' AND description = 'UNKNOWN';

--- a/warehouse/sql/V1_0_0_3__fix_targets.sql
+++ b/warehouse/sql/V1_0_0_3__fix_targets.sql
@@ -1,0 +1,13 @@
+-- fixes two errant targets
+--
+-- there is a corresponding patch script in reporting, so this doesn't trigger a migrate
+
+USE ${schemaName};
+
+UPDATE target SET description = 'Statistics and Probability: Summarize, represent, and interpret data on a single count or measurement variable.'
+  WHERE natural_id = 'S-ID|P';
+DELETE FROM target WHERE natural_id = 'S-ID|Q';
+
+UPDATE target SET description = 'Geometry: Define trigonometric ratios and solve problems involving right triangles.'
+  WHERE natural_id = 'G-SRT|O';
+DELETE FROM target WHERE natural_id = 'G-SRT|P';


### PR DESCRIPTION
Turns out that the UNKNOWN targets were duplicates of targets with invalid ids. So, the descriptions for the UNKNOWN targets are updated and the targets with invalid ids are removed. I verified that there are no items referencing the targets with invalid ids.