### PR TITLE
Add chunk processing tracking to the user_report table.

### DIFF
--- a/reporting/sql/V1_1_0_1__add_user_report_chunk_tracking.sql
+++ b/reporting/sql/V1_1_0_1__add_user_report_chunk_tracking.sql
@@ -1,6 +1,5 @@
--- Modify user_report table to track chunk completion and remove unused job_execution_id column
+-- Modify user_report table to track chunk completion
 USE ${schemaName};
 
-ALTER TABLE user_report DROP COLUMN job_execution_id;
 ALTER TABLE user_report ADD COLUMN total_chunk_count INT NOT NULL DEFAULT 0;
 ALTER TABLE user_report ADD COLUMN complete_chunk_count INT NOT NULL DEFAULT 0;

--- a/reporting/sql/V1_1_0_1__add_user_report_chunk_tracking.sql
+++ b/reporting/sql/V1_1_0_1__add_user_report_chunk_tracking.sql
@@ -1,0 +1,6 @@
+-- Modify user_report table to track chunk completion and remove unused job_execution_id column
+USE ${schemaName};
+
+ALTER TABLE user_report DROP COLUMN job_execution_id;
+ALTER TABLE user_report ADD COLUMN total_chunk_count INT NOT NULL DEFAULT 0;
+ALTER TABLE user_report ADD COLUMN complete_chunk_count INT NOT NULL DEFAULT 0;


### PR DESCRIPTION
Now that we're doing cross-pod fan-out during report generation, we need a shared point for tracking how many student "chunks" have been processed when generating a large report.  This PR adds "total" and "completed" columns to the user_report table.  It also removes the job_execution_id column that will no longer be used once the report processor is converted from spring batch to spring stream processing.