### PR TITLE
DWR-389 - Triggers and audit tables for exam and exam child tables

### DIFF
--- a/warehouse/sql/V1_1_0_4__exam_audit.sql
+++ b/warehouse/sql/V1_1_0_4__exam_audit.sql
@@ -9,6 +9,9 @@ USE ${schemaName};
   Audit records are created for update and delete.
   Timestamp is required for exam updates that include creating a new child record.
   Child records do now have the import id.
+
+  Through the application, after insert, some exam records can be updated, some deleted or both as noted below.
+  Triggers are added consistently for update and delete on all exam tables.
 */
 
 ALTER TABLE exam_claim_score
@@ -63,6 +66,7 @@ CREATE TABLE IF NOT EXISTS audit_exam (
   prim_disability_type VARCHAR(3) NULL
 );
 
+-- UPDATE
 CREATE TRIGGER trg__exam__update
 BEFORE UPDATE ON exam
 FOR EACH ROW
@@ -108,6 +112,51 @@ FOR EACH ROW
       OLD.language_code,
       OLD.prim_disability_type);
 
+-- DELETE
+CREATE TRIGGER trg__exam__delete
+BEFORE DELETE ON exam
+FOR EACH ROW
+  INSERT INTO audit_exam (action, database_user, exam_id, type_id, school_year, asmt_id, asmt_version,
+                          opportunity, oppId, completeness_id, administration_condition_id, session_id, scale_score,
+                          scale_score_std_err, performance_level, completed_at, import_id, update_import_id, deleted,
+                          created, updated, grade_id, student_id, school_id, iep, lep, section504,
+                          economic_disadvantage, migrant_status, eng_prof_lvl, t3_program_type, language_code,
+                          prim_disability_type)
+  VALUES
+    (
+      'delete',
+      USER(),
+      OLD.id,
+      OLD.type_id,
+      OLD.school_year,
+      OLD.asmt_id,
+      OLD.asmt_version,
+      OLD.opportunity,
+      OLD.oppId,
+      OLD.completeness_id,
+      OLD.administration_condition_id,
+      OLD.session_id,
+      OLD.scale_score,
+      OLD.scale_score_std_err,
+      OLD.performance_level,
+      OLD.completed_at,
+      OLD.import_id,
+      OLD.update_import_id,
+      OLD.deleted,
+      OLD.created,
+      OLD.updated,
+      OLD.grade_id,
+      OLD.student_id,
+      OLD.school_id,
+      OLD.iep,
+      OLD.lep,
+      OLD.section504,
+      OLD.economic_disadvantage,
+      OLD.migrant_status,
+      OLD.eng_prof_lvl,
+      OLD.t3_program_type,
+      OLD.language_code,
+      OLD.prim_disability_type);
 
 /*
   exam_claim_score audit table and triggers
@@ -127,6 +176,7 @@ CREATE TABLE IF NOT EXISTS audit_exam_claim_score (
   category TINYINT NULL
 );
 
+-- UPDATE
 CREATE TRIGGER trg__exam_claim_score__update
 BEFORE UPDATE ON exam_claim_score
 FOR EACH ROW
@@ -136,6 +186,24 @@ FOR EACH ROW
   VALUES
     (
       'update',
+      USER(),
+      OLD.id,
+      OLD.exam_id,
+      OLD.subject_claim_score_id,
+      OLD.scale_score,
+      OLD.scale_score_std_err,
+      OLD.category);
+
+-- DELETE
+CREATE TRIGGER trg__exam_claim_score__delete
+BEFORE DELETE ON exam_claim_score
+FOR EACH ROW
+  INSERT INTO audit_exam_claim_score (
+    action, database_user, exam_claim_score_id, exam_id, subject_claim_score_id, scale_score, scale_score_std_err, category
+  )
+  VALUES
+    (
+      'delete',
       USER(),
       OLD.id,
       OLD.exam_id,
@@ -158,6 +226,22 @@ CREATE TABLE IF NOT EXISTS audit_exam_available_accommodation (
   accommodation_id SMALLINT(6) NOT NULL
 );
 
+-- UPDATE
+CREATE TRIGGER trg__exam_available_accommodation__update
+BEFORE UPDATE ON exam_available_accommodation
+FOR EACH ROW
+  INSERT INTO audit_exam_available_accommodation (
+    action, database_user, exam_id, accommodation_id
+  )
+  VALUES
+    (
+      'update',
+      USER(),
+      OLD.exam_id,
+      OLD.accommodation_id
+    );
+
+-- DELETE
 CREATE TRIGGER trg__exam_available_accommodation__delete
 BEFORE DELETE ON exam_available_accommodation
 FOR EACH ROW
@@ -197,6 +281,7 @@ CREATE TABLE IF NOT EXISTS audit_exam_item (
   trait_conventions_score_status VARCHAR(50) NULL
 );
 
+-- UPDATE
 CREATE TRIGGER trg__exam_item__update
 BEFORE UPDATE ON exam_item
 FOR EACH ROW
@@ -225,6 +310,7 @@ FOR EACH ROW
       OLD.trait_conventions_score_status
     );
 
+-- DELETE
 CREATE TRIGGER trg__exam_item__delete
 BEFORE DELETE ON exam_item
 FOR EACH ROW

--- a/warehouse/sql/V1_1_0_4__exam_audit.sql
+++ b/warehouse/sql/V1_1_0_4__exam_audit.sql
@@ -1,0 +1,255 @@
+-- Create tables to hold audit for update and delete of exams
+-- 1: create audit tables
+-- 2: create triggers
+
+#USE ${schemaName};
+
+/*
+  exam audit table and triggers
+  exam can be updated
+*/
+
+CREATE TABLE IF NOT EXISTS audit_exam (
+  id BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  action VARCHAR(8) NOT NULL,
+  audited TIMESTAMP(6) DEFAULT CURRENT_TIMESTAMP(6) NOT NULL,
+  database_user VARCHAR(255) NOT NULL,
+  exam_id BIGINT NOT NULL,
+  type_id TINYINT NOT NULL,
+  school_year SMALLINT(6) NOT NULL,
+  asmt_id INT NOT NULL,
+  asmt_version VARCHAR(30) NULL,
+  opportunity INT NULL,
+  oppId VARCHAR(60) NULL,
+  completeness_id TINYINT NOT NULL,
+  administration_condition_id TINYINT NOT NULL,
+  session_id VARCHAR(128) NOT NULL,
+  scale_score FLOAT NULL,
+  scale_score_std_err FLOAT NULL,
+  performance_level TINYINT NULL,
+  completed_at TIMESTAMP NOT NULL,
+  import_id BIGINT NOT NULL,
+  update_import_id BIGINT NOT NULL,
+  deleted TINYINT NOT NULL,
+  created TIMESTAMP(6) NOT NULL,
+  updated TIMESTAMP(6) NOT NULL,
+  grade_id TINYINT NOT NULL,
+  student_id INT NOT NULL,
+  school_id INT NOT NULL,
+  iep TINYINT NOT NULL,
+  lep TINYINT NOT NULL,
+  section504 TINYINT NULL,
+  economic_disadvantage TINYINT NOT NULL,
+  migrant_status TINYINT NULL,
+  eng_prof_lvl VARCHAR(20) NULL,
+  t3_program_type VARCHAR(20) NULL,
+  language_code VARCHAR(3) NULL,
+  prim_disability_type VARCHAR(3) NULL
+);
+
+DROP TRIGGER IF EXISTS trg__exam__update;
+
+CREATE TRIGGER trg__exam__update
+BEFORE UPDATE ON exam
+FOR EACH ROW
+  INSERT INTO audit_exam (action, audited, database_user, exam_id, type_id, school_year, asmt_id, asmt_version,
+                          opportunity, oppId, completeness_id, administration_condition_id, session_id, scale_score,
+                          scale_score_std_err, performance_level, completed_at, import_id, update_import_id, deleted,
+                          created, updated, grade_id, student_id, school_id, iep, lep, section504,
+                          economic_disadvantage, migrant_status, eng_prof_lvl, t3_program_type, language_code,
+                          prim_disability_type)
+  VALUES
+    (
+      'update',
+      NOW(),
+      USER(),
+      OLD.id,
+      OLD.type_id,
+      OLD.school_year,
+      OLD.asmt_id,
+      OLD.asmt_version,
+      OLD.opportunity,
+      OLD.oppId,
+      OLD.completeness_id,
+      OLD.administration_condition_id,
+      OLD.session_id,
+      OLD.scale_score,
+      OLD.scale_score_std_err,
+      OLD.performance_level,
+      OLD.completed_at,
+      OLD.import_id,
+      OLD.update_import_id,
+      OLD.deleted,
+      OLD.created,
+      OLD.updated,
+      OLD.grade_id,
+      OLD.student_id,
+      OLD.school_id,
+      OLD.iep,
+      OLD.lep,
+      OLD.section504,
+      OLD.economic_disadvantage,
+      OLD.migrant_status,
+      OLD.eng_prof_lvl,
+      OLD.t3_program_type,
+      OLD.language_code,
+      OLD.prim_disability_type);
+
+
+/*
+  exam_claim_score audit table and triggers
+  exam_claim_score can be updated
+*/
+
+CREATE TABLE IF NOT EXISTS audit_exam_claim_score (
+  id BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  action VARCHAR(8) NOT NULL,
+  audited TIMESTAMP(6) DEFAULT CURRENT_TIMESTAMP(6) NOT NULL,
+  database_user VARCHAR(255) NOT NULL,
+  exam_claim_score_id BIGINT NOT NULL,
+  exam_id BIGINT NOT NULL,
+  subject_claim_score_id SMALLINT(6) NOT NULL,
+  scale_score FLOAT NULL,
+  scale_score_std_err FLOAT NULL,
+  category TINYINT NULL
+);
+
+DROP TRIGGER IF EXISTS trg__exam_claim_score__update;
+
+CREATE TRIGGER trg__exam_claim_score__update
+BEFORE UPDATE ON exam_claim_score
+FOR EACH ROW
+  INSERT INTO audit_exam_claim_score (
+    action, audited, database_user, exam_claim_score_id, exam_id, subject_claim_score_id, scale_score, scale_score_std_err, category
+  )
+  VALUES
+    (
+      'update',
+      NOW(),
+      USER(),
+      OLD.id,
+      OLD.exam_id,
+      OLD.subject_claim_score_id,
+      OLD.scale_score,
+      OLD.scale_score_std_err,
+      OLD.category);
+
+/*
+  exam_available_accommodation audit table and triggers
+  exam_available_accommodation can be deleted
+*/
+
+CREATE TABLE IF NOT EXISTS audit_exam_available_accommodation (
+  id BIGINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  action VARCHAR(8) NOT NULL,
+  audited TIMESTAMP(6) DEFAULT CURRENT_TIMESTAMP(6) NOT NULL,
+  database_user VARCHAR(255) NOT NULL,
+  exam_id BIGINT NOT NULL,
+  accommodation_id SMALLINT(6) NOT NULL
+);
+
+DROP TRIGGER IF EXISTS trg__exam_available_accommodation__delete;
+
+CREATE TRIGGER trg__exam_available_accommodation__delete
+BEFORE DELETE ON exam_available_accommodation
+FOR EACH ROW
+  INSERT INTO audit_exam_available_accommodation (
+    action, audited, database_user, exam_id, accommodation_id
+  )
+  VALUES
+    (
+      'delete',
+      NOW(),
+      USER(),
+      OLD.exam_id,
+      OLD.accommodation_id
+    );
+
+/*
+  exam_item audit table and triggers
+  exam_item can be updated and deleted
+*/
+
+CREATE TABLE IF NOT EXISTS audit_exam_item (
+  id bigint NOT NULL AUTO_INCREMENT PRIMARY KEY,
+  action VARCHAR(8) NOT NULL,
+  audited TIMESTAMP(6) DEFAULT CURRENT_TIMESTAMP(6) NOT NULL,
+  database_user VARCHAR(255) NOT NULL,
+  exam_item_id BIGINT NOT NULL,
+  exam_id BIGINT NOT NULL,
+  item_id INT NOT NULL,
+  score FLOAT NOT NULL,
+  score_status VARCHAR(50) NULL,
+  position SMALLINT(6) NOT NULL,
+  response TEXT NULL,
+  trait_evidence_elaboration_score FLOAT NULL,
+  trait_evidence_elaboration_score_status VARCHAR(50) NULL,
+  trait_organization_purpose_score FLOAT NULL,
+  trait_organization_purpose_score_status VARCHAR(50) NULL,
+  trait_conventions_score FLOAT NULL,
+  trait_conventions_score_status VARCHAR(50) NULL
+);
+
+DROP TRIGGER IF EXISTS trg__exam_item__update;
+
+CREATE TRIGGER trg__exam_item__update
+BEFORE UPDATE ON exam_item
+FOR EACH ROW
+  INSERT INTO audit_exam_item (
+    action, audited, database_user, exam_item_id, exam_id, item_id, score,
+    score_status, position, response, trait_evidence_elaboration_score,
+    trait_evidence_elaboration_score_status, trait_organization_purpose_score,
+    trait_organization_purpose_score_status, trait_conventions_score, trait_conventions_score_status
+  )
+  VALUES
+    (
+      'update',
+      NOW(),
+      USER(),
+      OLD.id,
+      OLD.exam_id,
+      OLD.item_id,
+      OLD.score,
+      OLD.score_status,
+      OLD.position,
+      OLD.response,
+      OLD.trait_evidence_elaboration_score,
+      OLD.trait_evidence_elaboration_score_status,
+      OLD.trait_organization_purpose_score,
+      OLD.trait_organization_purpose_score_status,
+      OLD.trait_conventions_score,
+      OLD.trait_conventions_score_status
+    );
+
+DROP TRIGGER IF EXISTS trg__exam_item__delete;
+
+CREATE TRIGGER trg__exam_item__delete
+BEFORE DELETE ON exam_item
+FOR EACH ROW
+  INSERT INTO audit_exam_item (
+    action, audited, database_user, exam_item_id, exam_id, item_id, score,
+    score_status, position, response, trait_evidence_elaboration_score,
+    trait_evidence_elaboration_score_status, trait_organization_purpose_score,
+    trait_organization_purpose_score_status, trait_conventions_score, trait_conventions_score_status
+  )
+  VALUES
+    (
+      'delete',
+      NOW(),
+      USER(),
+      OLD.id,
+      OLD.exam_id,
+      OLD.item_id,
+      OLD.score,
+      OLD.score_status,
+      OLD.position,
+      OLD.response,
+      OLD.trait_evidence_elaboration_score,
+      OLD.trait_evidence_elaboration_score_status,
+      OLD.trait_organization_purpose_score,
+      OLD.trait_organization_purpose_score_status,
+      OLD.trait_conventions_score,
+      OLD.trait_conventions_score_status
+    );
+
+


### PR DESCRIPTION
Starting with exam and related child tables. 
The following audit tables are created:
audit_exam
audit_exam_claim_score
audit_exam_available_accommodation
audit_exam_item

Each table has:
  id - the primary key of the table
  action - 'delete' or 'update'
  audited - timestamp when audit record created
  database_user - the MySql user name and host ( so we could filter DBA vs Application )
  Then each field in the source table.

The tables being audited have triggers, currently:
exam - update (delete is soft)
exam_claim_score - update
exam_available_accommodation - delete
exam_item - update and delete

If we stick with triggers I think it may consider having update and delete triggers on all audited
tables.  For now I am only adding triggers for what our application does to the tables.

There are sample trt's that exercise triggers on the confluence design page.
Can get to it from the Jira also.
There are sequence numbers on trt's so they submit in order of hypothetical changes.

One concern I have is no trigger 'mute' feature for when updates may occur during a flyway migration.  Options others have mentioned include.
1. drop triggers and re add.  if we did this we would want a separate trigger drop and create script
2. set a variable to disable triggers and check if it is on in the trigger sql.


