### PR TITLE
DWR-1060 Make migrate table in synch with the olap migrate table.

### DIFF
--- a/reporting/sql/V1_1_0_4__update_migrate_table.sql
+++ b/reporting/sql/V1_1_0_4__update_migrate_table.sql
@@ -1,0 +1,5 @@
+-- Modify migrate table to be in synch with the migrate_olap schema
+
+USE ${schemaName};
+
+ALTER TABLE migrate MODIFY COLUMN size int;


### PR DESCRIPTION
Olap migrate is done in a batch size that is larger than `smallint`.

While the reporting `migrate` table is planned (at least for now) to be a different physical table, it does not have to be this way. So I felt that these tables should be in synch.