### PR TITLE
Add a status_indicator table to the olap schema for determining DB co…

### DIFF
--- a/reporting_olap/sql/V1_0_0_0__ddl.sql
+++ b/reporting_olap/sql/V1_0_0_0__ddl.sql
@@ -269,3 +269,8 @@ CREATE TABLE fact_student_ica_exam_for_longitudinal (
   CONSTRAINT fk__fact_student_ica_exam__school FOREIGN KEY(school_id) REFERENCES school(id),
   CONSTRAINT fk__fact_student_ica_exam__student FOREIGN KEY(student_id) REFERENCES student(id)
  )   COMPOUND SORTKEY (school_id, asmt_id);
+
+CREATE TABLE status_indicator (
+  id smallint encode delta PRIMARY KEY,
+  updated timestamp DEFAULT current_timestamp
+);

--- a/reporting_olap/sql/V1_0_0_1__dml.sql
+++ b/reporting_olap/sql/V1_0_0_1__dml.sql
@@ -28,3 +28,6 @@ INSERT INTO exam_claim_score_mapping (subject_claim_score_id, num) VALUES
   (12, 2),
   (13, 3),
   (14, 4);
+
+INSERT INTO status_indicator (id) VALUES
+  (1);


### PR DESCRIPTION
…nnection health

After discussing with @malaffoon we couldn't come up with a better way to test the OLAP/Redshift DB for read/write health without potentially mangling live data.

This PR creates a small table with a single row used for testing read/write access from our application to the database.