### PR TITLE
Replace translation table unique index with primary key

### DIFF
--- a/reporting/sql/V1_1_0_6__add_translation_primary_key.sql
+++ b/reporting/sql/V1_1_0_6__add_translation_primary_key.sql
@@ -1,0 +1,19 @@
+-- Replace the UNIQUE INDEX on the translation table with a primary key
+
+USE ${schemaName};
+
+CREATE TABLE translation_temp (
+  namespace varchar(10) NOT NULL,
+  label_code varchar(128) NOT NULL,
+  language_code varchar(3) NOT NULL,
+  label text,
+  PRIMARY KEY (namespace, label_code, language_code)
+);
+
+INSERT INTO translation_temp (namespace, label_code, language_code, label)
+  SELECT namespace, label_code, language_code, label
+  FROM translation;
+
+DROP TABLE translation;
+
+RENAME TABLE translation_temp TO translation;

--- a/reporting/sql/V1_1_0_6__add_translation_primary_key.sql
+++ b/reporting/sql/V1_1_0_6__add_translation_primary_key.sql
@@ -2,18 +2,6 @@
 
 USE ${schemaName};
 
-CREATE TABLE translation_temp (
-  namespace varchar(10) NOT NULL,
-  label_code varchar(128) NOT NULL,
-  language_code varchar(3) NOT NULL,
-  label text,
-  PRIMARY KEY (namespace, label_code, language_code)
-);
-
-INSERT INTO translation_temp (namespace, label_code, language_code, label)
-  SELECT namespace, label_code, language_code, label
-  FROM translation;
-
-DROP TABLE translation;
-
-RENAME TABLE translation_temp TO translation;
+ALTER TABLE translation
+  ADD PRIMARY KEY (namespace, label_code, language_code),
+  DROP INDEX idx__translation__namespace_label_code_language_code;


### PR DESCRIPTION
This PR fixes a reported bug with the translation table missing a Primary Key:
```
2017-07-11 20:59:57 11502 [ERROR] Table ./reporting_test/translation has no primary key in InnoDB data dictionary, but has one in MySQL! If you created the table with a MySQL version < 3.23.54 and did not define a primary key, but defined a unique key with all non-NULL columns, then MySQL internally treats that key as the primary key. You can fix this error by dump + DROP + CREATE + reimport of the table.
2017-07-11 20:59:57 11502 [Warning] Table ./reporting_test/translation key_used_on_scan is 0 even though there is no primary key inside InnoDB.
```
Unfortunately, I've been unable to reproduce the warning locally.  An obvious fix is to simply replace the UNIQUE INDEX with a multi-column PRIMARY KEY.