### PR TITLE
Add configurable instructional resources.

### DIFF
--- a/reporting/sql/V1_1_0_11__refactor_instructional_resource.sql
+++ b/reporting/sql/V1_1_0_11__refactor_instructional_resource.sql
@@ -1,0 +1,15 @@
+-- Refactor instructional_resource table to allow organization-level and performance-level
+-- instructional resources.
+
+USE ${schemaName};
+
+ALTER TABLE instructional_resource
+  DROP PRIMARY KEY,
+  CHANGE name asmt_natural_id VARCHAR(250) NOT NULL,
+  ADD COLUMN performance_level TINYINT DEFAULT NULL,
+  ADD COLUMN org_level VARCHAR(15) NOT NULL, -- 'SBAC' | 'State' | 'DistrictGroup' | 'District' | 'SchoolGroup'
+  ADD COLUMN org_natural_id VARCHAR(250) DEFAULT NULL,
+  ADD PRIMARY KEY (asmt_natural_id, org_level, performance_level);
+
+UPDATE instructional_resource
+  SET org_level = 'SBAC';

--- a/reporting/sql/V1_1_0_11__refactor_instructional_resource.sql
+++ b/reporting/sql/V1_1_0_11__refactor_instructional_resource.sql
@@ -7,9 +7,9 @@ ALTER TABLE instructional_resource
   DROP PRIMARY KEY,
   CHANGE name asmt_natural_id VARCHAR(250) NOT NULL,
   ADD COLUMN performance_level TINYINT DEFAULT NULL,
-  ADD COLUMN org_level VARCHAR(15) NOT NULL, -- 'SBAC' | 'State' | 'DistrictGroup' | 'District' | 'SchoolGroup'
+  ADD COLUMN org_level VARCHAR(15) NOT NULL, -- 'System' | 'State' | 'DistrictGroup' | 'District' | 'SchoolGroup'
   ADD COLUMN org_natural_id VARCHAR(250) DEFAULT NULL,
   ADD PRIMARY KEY (asmt_natural_id, org_level, performance_level);
 
 UPDATE instructional_resource
-  SET org_level = 'SBAC';
+  SET org_level = 'System';

--- a/reporting/sql/instructional_resource_load.sql
+++ b/reporting/sql/instructional_resource_load.sql
@@ -1,0 +1,18 @@
+-- SAMPLE insertion of assessment-wide SBAC instructional resources.
+-- Modify this sample script to insert assessment-wide or performance-level
+--  instructional resources for SBAC.
+
+use reporting;
+
+INSERT INTO instructional_resource (asmt_natural_id, org_level, performance_level, resource) VALUES
+  ('SBAC-IAB-FIXED-G3M-NBT-MATH-3', 'SBAC', null, 'https://portal.smarterbalanced.org/library/en/v1.0/digital-library-connections-grade-3-number-and-operations-in-base-ten.docx'),
+  ('SBAC-IAB-FIXED-G4E-Revision-ELA-4', 'SBAC', null, 'https://portal.smarterbalanced.org/library/en/digital-library-connections-grade-4-revision.docx'),
+  ('SBAC-IAB-FIXED-G4E-BriefWrites-ELA-4', 'SBAC', null, 'https://portal.smarterbalanced.org/library/en/v1.0/digital-library-connections-grade-4-brief-writes.docx'),
+  ('SBAC-IAB-FIXED-G5M-NF-MATH-5', 'SBAC', null, 'https://portal.smarterbalanced.org/library/en/digital-library-connections-grade-5-fractions.docx'),
+  ('SBAC-IAB-FIXED-G6M-G-Calc-MATH-6', 'SBAC', null, 'https://portal.smarterbalanced.org/library/en/digital-library-connections-grade-6-geometry.docx'),
+  ('SBAC-IAB-FIXED-G7E-ReadLit-ELA-7', 'SBAC', null, 'https://portal.smarterbalanced.org/library/en/digital-library-connections-grade-7-read-literary-texts.docx'),
+  ('SBAC-IAB-FIXED-G7M-RP-Calc-MATH-7', 'SBAC', null, 'https://portal.smarterbalanced.org/library/en/digital-library-connections-grade-7-ratio-and-proportional-relationships.docx'),
+  ('SBAC-IAB-FIXED-G8E-Research-ELA-8', 'SBAC', null, 'https://portal.smarterbalanced.org/library/en/digital-library-connections-grade-8-research.docx'),
+  ('SBAC-IAB-FIXED-G11E-BriefWrites-ELA-11', 'SBAC', null, 'https://portal.smarterbalanced.org/library/en/digital-library-connections-high-school-brief-writes.docx'),
+  ('SBAC-IAB-FIXED-G11E-Revision-ELA-11', 'SBAC', null, 'https://portal.smarterbalanced.org/library/en/digital-library-connections-high-school-revision.docx'),
+  ('SBAC-IAB-FIXED-G11M-SP-Calc-MATH-11', 'SBAC', null, 'https://portal.smarterbalanced.org/library/en/digital-library-connections-high-school-statistics-and-probability.docx');

--- a/reporting/sql/instructional_resource_load.sql
+++ b/reporting/sql/instructional_resource_load.sql
@@ -1,18 +1,18 @@
--- SAMPLE insertion of assessment-wide SBAC instructional resources.
+-- SAMPLE insertion of assessment-wide System instructional resources.
 -- Modify this sample script to insert assessment-wide or performance-level
---  instructional resources for SBAC.
+--  instructional resources for the system.
 
 use reporting;
 
 INSERT INTO instructional_resource (asmt_natural_id, org_level, performance_level, resource) VALUES
-  ('SBAC-IAB-FIXED-G3M-NBT-MATH-3', 'SBAC', null, 'https://portal.smarterbalanced.org/library/en/v1.0/digital-library-connections-grade-3-number-and-operations-in-base-ten.docx'),
-  ('SBAC-IAB-FIXED-G4E-Revision-ELA-4', 'SBAC', null, 'https://portal.smarterbalanced.org/library/en/digital-library-connections-grade-4-revision.docx'),
-  ('SBAC-IAB-FIXED-G4E-BriefWrites-ELA-4', 'SBAC', null, 'https://portal.smarterbalanced.org/library/en/v1.0/digital-library-connections-grade-4-brief-writes.docx'),
-  ('SBAC-IAB-FIXED-G5M-NF-MATH-5', 'SBAC', null, 'https://portal.smarterbalanced.org/library/en/digital-library-connections-grade-5-fractions.docx'),
-  ('SBAC-IAB-FIXED-G6M-G-Calc-MATH-6', 'SBAC', null, 'https://portal.smarterbalanced.org/library/en/digital-library-connections-grade-6-geometry.docx'),
-  ('SBAC-IAB-FIXED-G7E-ReadLit-ELA-7', 'SBAC', null, 'https://portal.smarterbalanced.org/library/en/digital-library-connections-grade-7-read-literary-texts.docx'),
-  ('SBAC-IAB-FIXED-G7M-RP-Calc-MATH-7', 'SBAC', null, 'https://portal.smarterbalanced.org/library/en/digital-library-connections-grade-7-ratio-and-proportional-relationships.docx'),
-  ('SBAC-IAB-FIXED-G8E-Research-ELA-8', 'SBAC', null, 'https://portal.smarterbalanced.org/library/en/digital-library-connections-grade-8-research.docx'),
-  ('SBAC-IAB-FIXED-G11E-BriefWrites-ELA-11', 'SBAC', null, 'https://portal.smarterbalanced.org/library/en/digital-library-connections-high-school-brief-writes.docx'),
-  ('SBAC-IAB-FIXED-G11E-Revision-ELA-11', 'SBAC', null, 'https://portal.smarterbalanced.org/library/en/digital-library-connections-high-school-revision.docx'),
-  ('SBAC-IAB-FIXED-G11M-SP-Calc-MATH-11', 'SBAC', null, 'https://portal.smarterbalanced.org/library/en/digital-library-connections-high-school-statistics-and-probability.docx');
+  ('SBAC-IAB-FIXED-G3M-NBT-MATH-3', 'System', null, 'https://portal.smarterbalanced.org/library/en/v1.0/digital-library-connections-grade-3-number-and-operations-in-base-ten.docx'),
+  ('SBAC-IAB-FIXED-G4E-Revision-ELA-4', 'System', null, 'https://portal.smarterbalanced.org/library/en/digital-library-connections-grade-4-revision.docx'),
+  ('SBAC-IAB-FIXED-G4E-BriefWrites-ELA-4', 'System', null, 'https://portal.smarterbalanced.org/library/en/v1.0/digital-library-connections-grade-4-brief-writes.docx'),
+  ('SBAC-IAB-FIXED-G5M-NF-MATH-5', 'System', null, 'https://portal.smarterbalanced.org/library/en/digital-library-connections-grade-5-fractions.docx'),
+  ('SBAC-IAB-FIXED-G6M-G-Calc-MATH-6', 'System', null, 'https://portal.smarterbalanced.org/library/en/digital-library-connections-grade-6-geometry.docx'),
+  ('SBAC-IAB-FIXED-G7E-ReadLit-ELA-7', 'System', null, 'https://portal.smarterbalanced.org/library/en/digital-library-connections-grade-7-read-literary-texts.docx'),
+  ('SBAC-IAB-FIXED-G7M-RP-Calc-MATH-7', 'System', null, 'https://portal.smarterbalanced.org/library/en/digital-library-connections-grade-7-ratio-and-proportional-relationships.docx'),
+  ('SBAC-IAB-FIXED-G8E-Research-ELA-8', 'System', null, 'https://portal.smarterbalanced.org/library/en/digital-library-connections-grade-8-research.docx'),
+  ('SBAC-IAB-FIXED-G11E-BriefWrites-ELA-11', 'System', null, 'https://portal.smarterbalanced.org/library/en/digital-library-connections-high-school-brief-writes.docx'),
+  ('SBAC-IAB-FIXED-G11E-Revision-ELA-11', 'System', null, 'https://portal.smarterbalanced.org/library/en/digital-library-connections-high-school-revision.docx'),
+  ('SBAC-IAB-FIXED-G11M-SP-Calc-MATH-11', 'System', null, 'https://portal.smarterbalanced.org/library/en/digital-library-connections-high-school-statistics-and-probability.docx');


### PR DESCRIPTION
There is a requirement that we can have 0-1 Instructional Resource link per assessment, organization level, performance level.

A null performance level indicates an assessment-wide instructional resource not bound to a single performance level.

IABs may have one instructional resource for each of the 3 "Reporting Catogories"
ICAs/Summatives may have one instructional resource for each of the 4 "Achievement Levels"