### PR TITLE
Remove invalid instructional_resource primary key in favor of a uniqu…

### DIFF
--- a/reporting/sql/V1_1_0_12__fix_instructional_resource_primary_key.sql
+++ b/reporting/sql/V1_1_0_12__fix_instructional_resource_primary_key.sql
@@ -4,4 +4,4 @@ USE ${schemaName};
 
 ALTER TABLE instructional_resource
   DROP PRIMARY KEY,
-  ADD UNIQUE INDEX idx__instructional_resource__asmt_level_perf_org (asmt_natural_id, org_level, performance_level, org_natural_id);
+  ADD UNIQUE INDEX idx__instructional_resource (asmt_natural_id, org_level, performance_level, org_natural_id);

--- a/reporting/sql/V1_1_0_12__fix_instructional_resource_primary_key.sql
+++ b/reporting/sql/V1_1_0_12__fix_instructional_resource_primary_key.sql
@@ -1,0 +1,7 @@
+-- Update instructional_resource primary key to allow a single value per institution
+
+USE ${schemaName};
+
+ALTER TABLE instructional_resource
+  DROP PRIMARY KEY,
+  ADD UNIQUE INDEX idx__instructional_resource__asmt_level_perf_org (asmt_natural_id, org_level, performance_level, org_natural_id);


### PR DESCRIPTION
…e index that allows nullables

While building out the API I found that the previous PRIMARY KEY on (asmt_natural_id, org_level, performance_level) doesn't work.  We may have an entry for those values for each organization at the org_level.

Unfortunately, this means the table cannot have a PRIMARY KEY because it would need to include the NULLABLE org_natural_id column.  To have a valid PRIMARY KEY we would need to introduce an auto-incrementing id column, but I didn't see much need.

Instead, I'm creating a UNIQUE INDEX on (asmt_natural_id, org_level, performance_level, org_natural_id) to ensure data integrity.