### PR TITLE
noticed this running locally

### DIFF
--- a/validation/sql/total-iab-scores/warehouse.sql
+++ b/validation/sql/total-iab-scores/warehouse.sql
@@ -1,5 +1,5 @@
 SELECT
-    sum(scale_score),
+    sum(round(scale_score)),
     sum(scale_score_std_err),
     sum(performance_level)
   FROM exam

--- a/validation/sql/total-ica-scores/warehouse.sql
+++ b/validation/sql/total-ica-scores/warehouse.sql
@@ -1,5 +1,5 @@
 SELECT
-    sum(scale_score),
+    sum(round(scale_score)),
     sum(scale_score_std_err),
     sum(performance_level)
   FROM exam

--- a/warehouse/sql/bulk_delete_exam.sql
+++ b/warehouse/sql/bulk_delete_exam.sql
@@ -16,7 +16,8 @@ SET @select_exam_ids = '{placeholder for query that identifies exams to be delet
 -- ------------------------------------------------------------------------------------------------------------
 -- STEP 2 (optional): turn off auditing
 -- ------------------------------------------------------------------------------------------------------------
-UPDATE setting SET value = 'FALSE' WHERE name = 'AUDIT_TRIGGER_ENABLE';
+SELECT value INTO @audit_setting FROM setting WHERE name = 'AUDIT_TRIGGER_ENABLE';
+UPDATE setting SET value = 'FALSE' WHERE name = 'AUDIT_TRIGGER_ENABLE' AND value != 'FALSE';
 
 -- ------------------------------------------------------------------------------------------------------------
 -- STEP 3: initialization
@@ -133,4 +134,4 @@ DROP PROCEDURE loop_by_partition;
 -- ------------------------------------------------------------------------------------------------------------
 -- STEP 10 (optional): turn auditing back on (if needed)
 -- ------------------------------------------------------------------------------------------------------------
-UPDATE setting SET value = 'TRUE' WHERE name = 'AUDIT_TRIGGER_ENABLE';
+UPDATE setting SET value = @audit_setting WHERE name = 'AUDIT_TRIGGER_ENABLE' AND value != @audit_setting;


### PR DESCRIPTION
If you look at the migrate scripts they round the scale_score when copying from warehouse to reporting. So i think the validation scripts need to do the same thing.