### PR TITLE
Refactor instructional_resource table to store Organization id as a d…

### DIFF
--- a/reporting/sql/V1_1_0_13__modify_instructional_resource_org_id.sql
+++ b/reporting/sql/V1_1_0_13__modify_instructional_resource_org_id.sql
@@ -1,0 +1,9 @@
+-- Refactor instructional_resource table to track organizations by database id rather than
+-- natural id.
+
+USE ${schemaName};
+
+ALTER TABLE instructional_resource
+  DROP INDEX idx__instructional_resource,
+  CHANGE org_natural_id org_id int,
+  ADD UNIQUE INDEX idx__instructional_resource (asmt_natural_id, org_level, performance_level, org_id);


### PR DESCRIPTION
…atabase id rather than a natural id

After discussing the Admin API for managing instructional resources with @agorina she pointed out that our SQL-managed SBAC instructional resources do not have an organization id.  This means we're free to use the database id as the instructional resource organization reference rather than a natural id.  Doing so greatly simplifies the admin API queries w.r.t. permission filtering.