### PR TITLE
flatten embargo schema

### DIFF
--- a/warehouse/sql/V1_1_0_25__flatten_embargo.sql
+++ b/warehouse/sql/V1_1_0_25__flatten_embargo.sql
@@ -1,0 +1,32 @@
+-- Modify embargo tables to be flat: columns instead of rows for different embargo scopes.
+
+USE ${schemaName};
+
+-- this assumes there is no real embargo data out there yet so just clear tables
+DELETE FROM district_embargo;
+DELETE FROM state_embargo;
+
+
+ALTER TABLE district_embargo
+  DROP PRIMARY KEY,
+  DROP FOREIGN KEY fk__district_embargo__embargo_scope,
+  DROP INDEX idx__district_embargo__embargo_scope,
+  DROP COLUMN embargo_scope_id,
+  DROP COLUMN enabled,
+  ADD PRIMARY KEY (district_id, school_year),
+  ADD COLUMN individual tinyint,
+  ADD COLUMN aggregate tinyint
+;
+
+ALTER TABLE state_embargo
+  DROP PRIMARY KEY,
+  DROP FOREIGN KEY fk__state_embargo__embargo_scope,
+  DROP INDEX idx__state_embargo__embargo_scope,
+  DROP COLUMN embargo_scope_id,
+  DROP COLUMN enabled,
+  ADD PRIMARY KEY (school_year),
+  ADD COLUMN individual tinyint,
+  ADD COLUMN aggregate tinyint
+;
+
+DROP TABLE embargo_scope;


### PR DESCRIPTION
Instead of having two rows in the embargo table, one for each scope (individual, aggregate) this denormalizes it into one row with two columns. 

Why? Cause it makes the queries easier. 
Why not? Uhmm, i guess this makes it slightly harder if we add a third embargo scope. 