### PR TITLE
Changes to support date range to percentile

### DIFF
--- a/reporting/sql/V1_1_0_3__percentile_changes.sql
+++ b/reporting/sql/V1_1_0_3__percentile_changes.sql
@@ -8,23 +8,23 @@ USE ${schemaName};
 ALTER TABLE percentile
   ADD COLUMN start_date DATE NOT NULL AFTER asmt_id,
   ADD COLUMN end_date DATE NOT NULL AFTER start_date,
-  ADD COLUMN min_score FLOAT AFTER standard_deviation,
-  ADD COLUMN max_score FLOAT AFTER min_score,
+  ADD COLUMN min_score FLOAT NOT NULL AFTER standard_deviation,
+  ADD COLUMN max_score FLOAT NOT NULL AFTER min_score,
   ADD UNIQUE INDEX idx__percentile__asmt_start_date_end_date (asmt_id, start_date, end_date);
 
 ALTER TABLE percentile_score
   CHANGE COLUMN percent percentile_rank TINYINT NOT NULL,
-  MODIFY COLUMN min_score FLOAT NOT NULL,
-  MODIFY COLUMN max_score FLOAT NOT NULL;
+  CHANGE COLUMN min_score min_inclusive FLOAT NOT NULL,
+  CHANGE COLUMN max_score max_exclusive FLOAT NOT NULL;
 
 ALTER TABLE staging_percentile
   ADD COLUMN start_date DATE NOT NULL AFTER asmt_id,
   ADD COLUMN end_date DATE NOT NULL AFTER start_date,
-  ADD COLUMN min_score FLOAT AFTER standard_deviation,
-  ADD COLUMN max_score FLOAT AFTER min_score,
+  ADD COLUMN min_score FLOAT NOT NULL AFTER standard_deviation,
+  ADD COLUMN max_score FLOAT NOT NULL AFTER min_score,
   ADD UNIQUE INDEX idx__staging_percentile__asmt_start_date_end_date (asmt_id, start_date, end_date);
 
 ALTER TABLE staging_percentile_score
   CHANGE COLUMN percent percentile_rank TINYINT NOT NULL,
-  MODIFY COLUMN min_score FLOAT NOT NULL,
-  MODIFY COLUMN max_score FLOAT NOT NULL;
+  CHANGE COLUMN min_score min_inclusive FLOAT NOT NULL,
+  CHANGE COLUMN max_score max_exclusive FLOAT NOT NULL;

--- a/reporting/sql/V1_1_0_3__percentile_changes.sql
+++ b/reporting/sql/V1_1_0_3__percentile_changes.sql
@@ -1,0 +1,30 @@
+-- Add support for percentile start and end date.
+-- add min and max score to percentile for optionally supplied min and max of the assessment.
+-- change percent to percentile_rank as a more appropriate name.
+-- modify the min and max score of the rank to float.
+
+USE ${schemaName};
+
+ALTER TABLE percentile
+  ADD COLUMN start_date DATE NOT NULL AFTER asmt_id,
+  ADD COLUMN end_date DATE NOT NULL AFTER start_date,
+  ADD COLUMN min_score FLOAT AFTER standard_deviation,
+  ADD COLUMN max_score FLOAT AFTER min_score,
+  ADD UNIQUE INDEX idx__percentile__asmt_start_date_end_date (asmt_id, start_date, end_date);
+
+ALTER TABLE percentile_score
+  CHANGE COLUMN percent percentile_rank TINYINT NOT NULL,
+  MODIFY COLUMN min_score FLOAT NOT NULL,
+  MODIFY COLUMN max_score FLOAT NOT NULL;
+
+ALTER TABLE staging_percentile
+  ADD COLUMN start_date DATE NOT NULL AFTER asmt_id,
+  ADD COLUMN end_date DATE NOT NULL AFTER start_date,
+  ADD COLUMN min_score FLOAT AFTER standard_deviation,
+  ADD COLUMN max_score FLOAT AFTER min_score,
+  ADD UNIQUE INDEX idx__staging_percentile__asmt_start_date_end_date (asmt_id, start_date, end_date);
+
+ALTER TABLE staging_percentile_score
+  CHANGE COLUMN percent percentile_rank TINYINT NOT NULL,
+  MODIFY COLUMN min_score FLOAT NOT NULL,
+  MODIFY COLUMN max_score FLOAT NOT NULL;

--- a/reporting/sql/V1_1_0_3__percentile_changes.sql
+++ b/reporting/sql/V1_1_0_3__percentile_changes.sql
@@ -14,6 +14,7 @@ ALTER TABLE percentile
 
 ALTER TABLE percentile_score
   CHANGE COLUMN percent percentile_rank TINYINT NOT NULL,
+  ADD COLUMN score float NOT NULL AFTER percentile_rank,
   CHANGE COLUMN min_score min_inclusive FLOAT NOT NULL,
   CHANGE COLUMN max_score max_exclusive FLOAT NOT NULL;
 
@@ -26,5 +27,6 @@ ALTER TABLE staging_percentile
 
 ALTER TABLE staging_percentile_score
   CHANGE COLUMN percent percentile_rank TINYINT NOT NULL,
+  ADD COLUMN score float NOT NULL AFTER percentile_rank,
   CHANGE COLUMN min_score min_inclusive FLOAT NOT NULL,
   CHANGE COLUMN max_score max_exclusive FLOAT NOT NULL;

--- a/warehouse/sql/V1_1_0_7__percentile_dates.sql
+++ b/warehouse/sql/V1_1_0_7__percentile_dates.sql
@@ -1,0 +1,18 @@
+-- Add support for percentile start and end date.
+-- add min and max score to percentile for optionally supplied min and max of the assessment.
+-- change percent to percentile_rank as a more appropriate name.
+-- modify the min and max score of the rank to float.
+
+USE ${schemaName};
+
+ALTER TABLE percentile
+  ADD COLUMN start_date DATE NOT NULL AFTER asmt_id,
+  ADD COLUMN end_date DATE NOT NULL AFTER start_date,
+  ADD COLUMN min_score FLOAT AFTER standard_deviation,
+  ADD COLUMN max_score FLOAT AFTER min_score,
+  ADD UNIQUE INDEX idx__percentile__asmt_start_date_end_date (asmt_id, start_date, end_date);
+
+ALTER TABLE percentile_score
+  CHANGE COLUMN percent percentile_rank TINYINT NOT NULL,
+  MODIFY COLUMN min_score FLOAT NOT NULL,
+  MODIFY COLUMN max_score FLOAT NOT NULL;

--- a/warehouse/sql/V1_1_0_7__percentile_dates.sql
+++ b/warehouse/sql/V1_1_0_7__percentile_dates.sql
@@ -8,11 +8,11 @@ USE ${schemaName};
 ALTER TABLE percentile
   ADD COLUMN start_date DATE NOT NULL AFTER asmt_id,
   ADD COLUMN end_date DATE NOT NULL AFTER start_date,
-  ADD COLUMN min_score FLOAT AFTER standard_deviation,
-  ADD COLUMN max_score FLOAT AFTER min_score,
+  ADD COLUMN min_score FLOAT NOT NULL AFTER standard_deviation,
+  ADD COLUMN max_score FLOAT NOT NULL AFTER min_score,
   ADD UNIQUE INDEX idx__percentile__asmt_start_date_end_date (asmt_id, start_date, end_date);
 
 ALTER TABLE percentile_score
   CHANGE COLUMN percent percentile_rank TINYINT NOT NULL,
-  MODIFY COLUMN min_score FLOAT NOT NULL,
-  MODIFY COLUMN max_score FLOAT NOT NULL;
+  CHANGE COLUMN min_score min_inclusive FLOAT NOT NULL,
+  CHANGE COLUMN max_score max_exclusive FLOAT NOT NULL;


### PR DESCRIPTION
Added start and end date.
Added unique index on asmt_id, start_date, end_date
- as mentioned below business logic will have to look for overlapping percentile start and end dates.
- changed min and max score in percentile_score to float
- added min and max score to percentile that represents the assessment.

Forgot to add i'm going to do some tests, maybe a PR with some tests tonight / tomorrow morning before merging