### PR TITLE
Remove reporting.translation.namespace column since it is no longer r…

### DIFF
--- a/reporting/sql/V1_2_0_5__remove_translation_namespace.sql
+++ b/reporting/sql/V1_2_0_5__remove_translation_namespace.sql
@@ -3,24 +3,10 @@
 
 use ${schemaName};
 
--- Create the new translation table
-CREATE TABLE new_translation (
-  label_code VARCHAR(128),
-  language_code VARCHAR(3),
-  label text,
-  PRIMARY KEY (language_code, label_code)
-);
-
--- Migrate existing translations into new table
-INSERT INTO new_translation (label_code, language_code, label)
-  SELECT
-    label_code,
-    language_code,
-    label
-  FROM translation;
-
-DROP TABLE translation;
-RENAME TABLE new_translation TO translation;
+ALTER TABLE translation
+  DROP PRIMARY KEY,
+  ADD PRIMARY KEY(language_code, label_code),
+  DROP COLUMN namespace;
 
 -- Remove the `namespace` column from the translation staging table.
 ALTER TABLE staging_translation

--- a/reporting/sql/V1_2_0_5__remove_translation_namespace.sql
+++ b/reporting/sql/V1_2_0_5__remove_translation_namespace.sql
@@ -17,4 +17,4 @@ RENAME TABLE translation TO accommodation_translation;
 ALTER TABLE staging_translation
   DROP COLUMN namespace;
 
-RENAME TABLE staging_translation TO accommodation_staging_translation;
+RENAME TABLE staging_translation TO staging_accommodation_translation;

--- a/reporting/sql/V1_2_0_5__remove_translation_namespace.sql
+++ b/reporting/sql/V1_2_0_5__remove_translation_namespace.sql
@@ -1,5 +1,7 @@
 -- Remove the `namespace` column from the translation table since we no longer
 -- require or respect it in the reporting application.
+-- Rename the existing reporting translation table to accommodation_translation
+-- to denote that it only contains accommodation translation labels
 
 use ${schemaName};
 
@@ -8,6 +10,11 @@ ALTER TABLE translation
   ADD PRIMARY KEY(language_code, label_code),
   DROP COLUMN namespace;
 
+-- Rename translation table to accommodation_translation
+RENAME TABLE translation TO accommodation_translation;
+
 -- Remove the `namespace` column from the translation staging table.
 ALTER TABLE staging_translation
   DROP COLUMN namespace;
+
+RENAME TABLE staging_translation TO accommodation_staging_translation;

--- a/reporting/sql/V1_2_0_5__remove_translation_namespace.sql
+++ b/reporting/sql/V1_2_0_5__remove_translation_namespace.sql
@@ -1,0 +1,24 @@
+-- Remove the `namespace` column from the translation table since we no longer
+-- require or respect it in the reporting application.
+
+use ${schemaName};
+
+-- Create the new translation table
+CREATE TABLE new_translation (
+  label_code VARCHAR(128),
+  language_code VARCHAR(3),
+  label text,
+  PRIMARY KEY (language_code, label_code)
+);
+
+-- Migrate existing translations into new table
+INSERT INTO new_translation (label_code, language_code, label)
+  SELECT
+    label_code,
+    language_code,
+    label
+  FROM translation;
+
+DROP TABLE translation;
+
+RENAME TABLE new_translation TO translation;

--- a/reporting/sql/V1_2_0_5__remove_translation_namespace.sql
+++ b/reporting/sql/V1_2_0_5__remove_translation_namespace.sql
@@ -20,5 +20,8 @@ INSERT INTO new_translation (label_code, language_code, label)
   FROM translation;
 
 DROP TABLE translation;
-
 RENAME TABLE new_translation TO translation;
+
+-- Remove the `namespace` column from the translation staging table.
+ALTER TABLE staging_translation
+  DROP COLUMN namespace;


### PR DESCRIPTION
…equired or respected.

I don't believe MySQL handles modifying a PRIMARY KEY very well, so I'm just creating a new table, copying values, then renaming it over the top of the old table.  Thoughts?