### PR TITLE
Trigger `asmt_target` table migration for Summative assessments.

### DIFF
--- a/warehouse/sql/V1_2_0_11__trigger_migarte_summative_targets.sql
+++ b/warehouse/sql/V1_2_0_11__trigger_migarte_summative_targets.sql
@@ -1,0 +1,17 @@
+USE ${schemaName};
+
+--TODO: NOTE remove this file from the production release
+-- trigger migration of summative assessments to load asmt_target table in reporting data-mart
+ INSERT INTO import (status, content, contentType, digest)
+    SELECT 0, ic.id, 'force summative asmt migrate', left(uuid(), 8) from import_content ic where name = 'PACKAGE';
+
+ SELECT max(id) INTO @import_id
+    FROM IMPORT WHERE contentType = 'force summative asmt migrate';
+
+ UPDATE asmt
+    SET update_import_id = @import_id
+    WHERE type_id = 3;
+
+ UPDATE import
+    SET status = 1
+    WHERE id = @import_id;

--- a/warehouse/sql/V1_2_0_11__trigger_migarte_summative_targets.sql
+++ b/warehouse/sql/V1_2_0_11__trigger_migarte_summative_targets.sql
@@ -1,12 +1,11 @@
 USE ${schemaName};
 
---TODO: NOTE remove this file from the production release
+-- NOTE: consider removing this file from the production release
 -- trigger migration of summative assessments to load asmt_target table in reporting data-mart
  INSERT INTO import (status, content, contentType, digest)
     SELECT 0, ic.id, 'force summative asmt migrate', left(uuid(), 8) from import_content ic where name = 'PACKAGE';
 
- SELECT max(id) INTO @import_id
-    FROM IMPORT WHERE contentType = 'force summative asmt migrate';
+ SELECT LAST_INSERT_ID() INTO @import_id;
 
  UPDATE asmt
     SET update_import_id = @import_id


### PR DESCRIPTION
I have a conflicting feeling if this should be included into Flyway or if this is something that we should do manually.

 It is only needed in QA because we have Summative data.

Please let me know what you think.