### PR TITLE
Adjust user group indexes.

### DIFF
--- a/reporting/sql/V1_2_0_11__user_groups-index.sql
+++ b/reporting/sql/V1_2_0_11__user_groups-index.sql
@@ -1,0 +1,12 @@
+use ${schemaName};
+
+ALTER TABLE user_student_group
+ DROP FOREIGN KEY fk__user_student_group__student_group,
+ DROP INDEX idx__user_student_group;
+
+ALTER TABLE user_student_group
+  -- reverse the order of columns in the index
+  ADD UNIQUE KEY idx__user_student_group(user_login, student_group_id),
+  -- add index to support FK
+  ADD INDEX idx__user_student_group__student_group(student_group_id),
+  ADD CONSTRAINT fk__user_student_group__student_group FOREIGN KEY (student_group_id) REFERENCES student_group(id);


### PR DESCRIPTION
Why? I am reviewing `slog_log` in both QA and UAT and modifying some indexes based on it. There are more to come.