### PR TITLE
RP-29, RP-30, add target_report to appropriate tables

### DIFF
--- a/reporting/sql/V1_3_0_0__target_report.sql
+++ b/reporting/sql/V1_3_0_0__target_report.sql
@@ -1,0 +1,10 @@
+-- Add target_report flag to subject assessment type
+
+USE ${schemaName};
+
+-- add without constraint, set default values, add constraint
+ALTER TABLE subject_asmt_type ADD COLUMN target_report tinyint;
+UPDATE subject_asmt_type SET target_report = IF(asmt_type_id = 3, 1, 0);
+ALTER TABLE subject_asmt_type MODIFY COLUMN target_report tinyint NOT NULL;
+
+ALTER TABLE staging_subject_asmt_type ADD COLUMN target_report tinyint NOT NULL;

--- a/reporting_olap/sql/V1_0_0_0__ddl.sql
+++ b/reporting_olap/sql/V1_0_0_0__ddl.sql
@@ -52,7 +52,6 @@ CREATE TABLE staging_subject_asmt_type (
   performance_level_count smallint NOT NULL,
   performance_level_standard_cutoff smallint,
   claim_score_performance_level_count smallint,
-  target_report boolean NOT NULL,
   migrate_id bigint NOT NULL
 );
 
@@ -224,7 +223,7 @@ CREATE TABLE staging_school_year (
 
 -- configuration
 CREATE TABLE school_year (
-  year smallint NOT NULL PRIMARY KEY SORTKEY 
+  year smallint NOT NULL PRIMARY KEY SORTKEY
 ) DISTSTYLE ALL;
 
 -- dimensions
@@ -274,7 +273,6 @@ CREATE TABLE subject_asmt_type (
   performance_level_count smallint NOT NULL,
   performance_level_standard_cutoff smallint,
   claim_score_performance_level_count smallint,
-  target_report boolean NOT NULL,
   UNIQUE (asmt_type_id, subject_id),
   CONSTRAINT fk__subject_asmt_type__type FOREIGN KEY(asmt_type_id) REFERENCES asmt_type(id),
   CONSTRAINT fk__subject_asmt_type__subject FOREIGN KEY(subject_id) REFERENCES subject(id)

--- a/reporting_olap/sql/V1_0_0_0__ddl.sql
+++ b/reporting_olap/sql/V1_0_0_0__ddl.sql
@@ -52,6 +52,7 @@ CREATE TABLE staging_subject_asmt_type (
   performance_level_count smallint NOT NULL,
   performance_level_standard_cutoff smallint,
   claim_score_performance_level_count smallint,
+  target_report boolean NOT NULL,
   migrate_id bigint NOT NULL
 );
 
@@ -273,6 +274,7 @@ CREATE TABLE subject_asmt_type (
   performance_level_count smallint NOT NULL,
   performance_level_standard_cutoff smallint,
   claim_score_performance_level_count smallint,
+  target_report boolean NOT NULL,
   UNIQUE (asmt_type_id, subject_id),
   CONSTRAINT fk__subject_asmt_type__type FOREIGN KEY(asmt_type_id) REFERENCES asmt_type(id),
   CONSTRAINT fk__subject_asmt_type__subject FOREIGN KEY(subject_id) REFERENCES subject(id)

--- a/reporting_olap/sql/V1_0_0_1__dml.sql
+++ b/reporting_olap/sql/V1_0_0_1__dml.sql
@@ -39,13 +39,13 @@ INSERT INTO subject_claim_score (id, subject_id, asmt_type_id, code) VALUES
   (13, 2, 3, '2-W'),
   (14, 2, 3, '4-CR');
 
-INSERT INTO subject_asmt_type (asmt_type_id, subject_id, performance_level_count, performance_level_standard_cutoff, claim_score_performance_level_count) VALUES
-  (1,  1,  4, 3,    3),
-  (1,  2,  4, 3,    3),
-  (2,  1,  3, null, null),
-  (2,  2,  3, null, null),
-  (3,  1,  4, 3,    3),
-  (3,  2,  4, 3,    3);
+INSERT INTO subject_asmt_type (asmt_type_id, subject_id, performance_level_count, performance_level_standard_cutoff, claim_score_performance_level_count, target_report) VALUES
+  (1,  1,  4, 3,    3,    false),
+  (1,  2,  4, 3,    3,    false),
+  (2,  1,  3, null, null, false),
+  (2,  2,  3, null, null, false),
+  (3,  1,  4, 3,    3,    true),
+  (3,  2,  4, 3,    3,    true);
 
 INSERT INTO status_indicator (id) VALUES
   (1);

--- a/reporting_olap/sql/V1_0_0_1__dml.sql
+++ b/reporting_olap/sql/V1_0_0_1__dml.sql
@@ -39,13 +39,13 @@ INSERT INTO subject_claim_score (id, subject_id, asmt_type_id, code) VALUES
   (13, 2, 3, '2-W'),
   (14, 2, 3, '4-CR');
 
-INSERT INTO subject_asmt_type (asmt_type_id, subject_id, performance_level_count, performance_level_standard_cutoff, claim_score_performance_level_count, target_report) VALUES
-  (1,  1,  4, 3,    3,    false),
-  (1,  2,  4, 3,    3,    false),
-  (2,  1,  3, null, null, false),
-  (2,  2,  3, null, null, false),
-  (3,  1,  4, 3,    3,    true),
-  (3,  2,  4, 3,    3,    true);
+INSERT INTO subject_asmt_type (asmt_type_id, subject_id, performance_level_count, performance_level_standard_cutoff, claim_score_performance_level_count) VALUES
+  (1,  1,  4, 3,    3),
+  (1,  2,  4, 3,    3),
+  (2,  1,  3, null, null),
+  (2,  2,  3, null, null),
+  (3,  1,  4, 3,    3),
+  (3,  2,  4, 3,    3);
 
 INSERT INTO status_indicator (id) VALUES
   (1);

--- a/reporting_olap/sql/V1_3_0_0__target_report.sql
+++ b/reporting_olap/sql/V1_3_0_0__target_report.sql
@@ -1,0 +1,37 @@
+SET SEARCH_PATH to ${schemaName};
+SET client_encoding = 'UTF8';
+
+
+CREATE TEMPORARY TABLE subject_asmt_type_temp AS SELECT * FROM subject_asmt_type;
+
+DROP TABLE subject_asmt_type;
+CREATE TABLE subject_asmt_type (
+  asmt_type_id smallint NOT NULL,
+  subject_id smallint NOT NULL SORTKEY,
+  performance_level_count smallint NOT NULL,
+  performance_level_standard_cutoff smallint,
+  claim_score_performance_level_count smallint,
+  target_report boolean NOT NULL,
+  UNIQUE (asmt_type_id, subject_id),
+  CONSTRAINT fk__subject_asmt_type__type FOREIGN KEY(asmt_type_id) REFERENCES asmt_type(id),
+  CONSTRAINT fk__subject_asmt_type__subject FOREIGN KEY(subject_id) REFERENCES subject(id)
+) DISTSTYLE ALL;
+
+INSERT INTO subject_asmt_type (asmt_type_id, subject_id, performance_level_count, performance_level_standard_cutoff, claim_score_performance_level_count, target_report)
+  (SELECT asmt_type_id, subject_id, performance_level_count, performance_level_standard_cutoff, claim_score_performance_level_count,
+          CASE asmt_type_id WHEN 3 THEN true ELSE false END
+   FROM subject_asmt_type_temp);
+
+DROP TABLE subject_asmt_type_temp;
+
+
+DROP TABLE staging_subject_asmt_type;
+CREATE TABLE staging_subject_asmt_type (
+  asmt_type_id smallint NOT NULL,
+  subject_id smallint NOT NULL,
+  performance_level_count smallint NOT NULL,
+  performance_level_standard_cutoff smallint,
+  claim_score_performance_level_count smallint,
+  target_report boolean NOT NULL,
+  migrate_id bigint NOT NULL
+);

--- a/warehouse/sql/V1_3_0_0__target_report.sql
+++ b/warehouse/sql/V1_3_0_0__target_report.sql
@@ -1,0 +1,9 @@
+-- Add target_report flag to subject assessment type
+
+USE ${schemaName};
+
+-- add without constraint, set default values, add constraint
+ALTER TABLE subject_asmt_type ADD COLUMN target_report tinyint;
+UPDATE subject_asmt_type SET target_report = IF(asmt_type_id = 3, 1, 0);
+ALTER TABLE subject_asmt_type MODIFY COLUMN target_report tinyint NOT NULL;
+


### PR DESCRIPTION
FYI @burzum619 : Redshift doesn't really support table modifications (the only way to do it is to copy the data into a temp table, recreate the modified table, and copy the data back). Because the migration to Redshift is relatively fast we have taken the general approach of not doing modification scripts for Redshift.

Hmm, as i'm typing this though i wonder if it would be worth doing for these changes. These are small supporting tables and having to migrate all the exam data just to modify them seems ... wrong. I may revisit the Redshift scripts.