### PR TITLE
add display order to language table

### DIFF
--- a/reporting/sql/V1_3_0_4__language_order.sql
+++ b/reporting/sql/V1_3_0_4__language_order.sql
@@ -1,0 +1,20 @@
+-- Add display order for languages.
+-- Remove all languages without an altcode / display order.
+
+USE ${schemaName};
+
+ALTER TABLE language
+  ADD COLUMN display_order smallint NULL;
+
+UPDATE language
+  SET display_order = CASE WHEN altcode = 'UU' THEN 99 ELSE CAST(altcode AS UNSIGNED) END
+  WHERE altcode IS NOT NULL;
+DELETE FROM language WHERE display_order IS NULL;
+
+ALTER TABLE language
+  DROP COLUMN altcode;
+
+ALTER TABLE staging_language
+  ADD COLUMN display_order smallint NULL,
+  DROP COLUMN altcode;
+

--- a/warehouse/sql/V1_3_0_4__language_order.sql
+++ b/warehouse/sql/V1_3_0_4__language_order.sql
@@ -1,0 +1,10 @@
+-- Add display order for languages
+
+USE ${schemaName};
+
+ALTER TABLE language
+  ADD COLUMN display_order smallint NULL;
+
+UPDATE language
+  SET display_order = CASE WHEN altcode = 'UU' THEN 99 ELSE CAST(altcode AS UNSIGNED) END
+  WHERE altcode IS NOT NULL;


### PR DESCRIPTION
The display order is used to reduce the languages in the reporting/olap tables. This is for RP-40.
The display order will be used to order the language entries in the widget.