### PR TITLE
the logic was wrong for setting printed_report for SB assessments!

### DIFF
--- a/reporting/sql/V1_4_0_2__alt_scoring.sql
+++ b/reporting/sql/V1_4_0_2__alt_scoring.sql
@@ -53,7 +53,7 @@ ALTER TABLE staging_exam_claim_score
 ALTER TABLE subject_asmt_type
   ADD COLUMN alt_score_performance_level_count TINYINT NULL   COMMENT 'NULL indicates subject asmt does not have alt scores',
   ADD COLUMN printed_report TINYINT;
-UPDATE subject_asmt_type SET printed_report = IF(asmt_type_id IN (1,2), 1, 0);
+UPDATE subject_asmt_type SET printed_report = IF(subject_id IN (1,2), 1, 0);
 ALTER TABLE subject_asmt_type MODIFY COLUMN printed_report TINYINT NOT NULL;
 
 ALTER TABLE subject_claim_score

--- a/warehouse/sql/V1_4_0_2__alt_scoring.sql
+++ b/warehouse/sql/V1_4_0_2__alt_scoring.sql
@@ -48,7 +48,7 @@ ALTER TABLE subject_asmt_type
   DROP COLUMN performance_level_standard_cutoff,
   DROP COLUMN claim_score_performance_level_count,
   ADD COLUMN printed_report TINYINT;
-UPDATE subject_asmt_type SET printed_report = IF(asmt_type_id IN (1,2), 1, 0);
+UPDATE subject_asmt_type SET printed_report = IF(subject_id IN (1,2), 1, 0);
 ALTER TABLE subject_asmt_type MODIFY COLUMN printed_report TINYINT NOT NULL;
 
 -- modify the subject claim score table to hold alt and claim score details


### PR DESCRIPTION
Yes, this will mess up the checksum but i'll deal with it, something like:
```
use reporting;
UPDATE schema_version SET checksum=-906927661 WHERE checksum=576876505 AND script='V1_4_0_2__alt_scoring.sql';
UPDATE subject_asmt_type SET printed_report=1 WHERE subject_id IN (1,2);

use warehouse;
UPDATE schema_version SET checksum=346153558 WHERE checksum=-1817477074 AND script='V1_4_0_2__alt_scoring.sql';
UPDATE subject_asmt_type SET printed_report=1 WHERE subject_id IN (1,2);
```