### PR TITLE
Add PIPELINE_FAILURE to import_status

### DIFF
--- a/migrations/warehouse/sql/V1_4_0_7__pipeline_failure_import_status.sql
+++ b/migrations/warehouse/sql/V1_4_0_7__pipeline_failure_import_status.sql
@@ -1,0 +1,7 @@
+-- Adds active version column to pipeline table
+-- Makes pipeline input_type column not null
+
+use ${schemaName};
+
+INSERT INTO import_status (id, name) VALUES
+(-7, 'PIPELINE_FAILURE');


### PR DESCRIPTION
Is this right, or should it also be consolidated to the 1.4.0 script? 