### PR TITLE
set schema explicitly

### DIFF
--- a/src/main/java/org/opentestsystem/rdw/schema/SchemaMigration.java
+++ b/src/main/java/org/opentestsystem/rdw/schema/SchemaMigration.java
@@ -19,6 +19,7 @@ public class SchemaMigration {
                 .table("schema_version")
                 .locations(migration.directory + "/sql")
                 .placeholders(Collections.singletonMap("schemaName", schemaName))
+                .schemas(schemaName)
                 .dataSource(dataSource)
                 .load();
     }


### PR DESCRIPTION
when using the admin DataSource, no default schema is set, this change allows that configuration to work correctly.

