### PR TITLE
insert trait purpose/category labels for ELA

### DIFF
--- a/migrations/reporting/sql/V2_4_0_0__update.sql
+++ b/migrations/reporting/sql/V2_4_0_0__update.sql
@@ -44,6 +44,16 @@ INSERT INTO subject_trait (id, subject_id, code, purpose, category, max_score) V
 (14, 2, 'SOCK_OPIN_CON', 'OPIN', 'CON', 2),
 (15, 2, 'SOCK_OPIN_EVI', 'OPIN', 'EVI', 4);
 
+INSERT INTO subject_translation (subject_id, label_code, label) VALUES
+(2, 'subject.ELA.trait.purpose.ARGU', 'Argument'),
+(2, 'subject.ELA.trait.purpose.EXPL', 'Explanatory'),
+(2, 'subject.ELA.trait.purpose.INFO', 'Informative'),
+(2, 'subject.ELA.trait.purpose.NARR', 'Narrative'),
+(2, 'subject.ELA.trait.purpose.OPIN', 'Opinion'),
+(2, 'subject.ELA.trait.category.ORG', 'Organization/Purpose'),
+(2, 'subject.ELA.trait.category.CON', 'Conventions'),
+(2, 'subject.ELA.trait.category.EVI', 'Evidence/Elaboration');
+
 CREATE TABLE staging_subject_trait (
    id smallint NOT NULL AUTO_INCREMENT PRIMARY KEY,
    subject_id smallint NOT NULL,

--- a/migrations/warehouse/sql/V2_4_0_0__update.sql
+++ b/migrations/warehouse/sql/V2_4_0_0__update.sql
@@ -42,6 +42,16 @@ INSERT INTO subject_trait (id, subject_id, code, purpose, category, max_score) V
 (14, 2, 'SOCK_OPIN_CON', 'OPIN', 'CON', 2),
 (15, 2, 'SOCK_OPIN_EVI', 'OPIN', 'EVI', 4);
 
+INSERT INTO subject_translation (subject_id, label_code, label) VALUES
+(2, 'subject.ELA.trait.purpose.ARGU', 'Argument'),
+(2, 'subject.ELA.trait.purpose.EXPL', 'Explanatory'),
+(2, 'subject.ELA.trait.purpose.INFO', 'Informative'),
+(2, 'subject.ELA.trait.purpose.NARR', 'Narrative'),
+(2, 'subject.ELA.trait.purpose.OPIN', 'Opinion'),
+(2, 'subject.ELA.trait.category.ORG', 'Organization/Purpose'),
+(2, 'subject.ELA.trait.category.CON', 'Conventions'),
+(2, 'subject.ELA.trait.category.EVI', 'Evidence/Elaboration');
+
 -- table to store exam-level trait scores
 CREATE TABLE exam_trait_score (
     id bigint NOT NULL AUTO_INCREMENT PRIMARY KEY,

--- a/src/test/java/org/opentestsystem/rdw/schema/SchemaMigrationWarehouseTest.java
+++ b/src/test/java/org/opentestsystem/rdw/schema/SchemaMigrationWarehouseTest.java
@@ -17,17 +17,17 @@ import static org.opentestsystem.rdw.schema.SchemaMigration.Migration.Warehouse;
 
 public class SchemaMigrationWarehouseTest {
 
-    private String rootJdbcUrl = "jdbc:mysql://localhost:3306";
-    private String rootUsername = "root"; //TODO drive from env?
-    private String schemaName = "warehouse_it_test";
-    private String jdbcUrl = "jdbc:mysql://localhost:3306/" + schemaName + "?useSSL=false&useLegacyDatetimeCode=false&characterEncoding=utf8";
+    private final String rootJdbcUrl = "jdbc:mysql://localhost:3306";
+    private final String rootUsername = "root"; //TODO drive from env?
+    private final String schemaName = "warehouse_it_test";
+    private final String jdbcUrl = "jdbc:mysql://localhost:3306/" + schemaName + "?useSSL=false&useLegacyDatetimeCode=false&characterEncoding=utf8";
     private DataSource dataSource;
 
     //class under test
     private SchemaMigration schemaMigration;
 
     @Before
-    public void setUp() throws Exception {
+    public void setUp() {
         runDDL("DROP DATABASE IF EXISTS " + schemaName);
         runDDL("CREATE DATABASE " + schemaName);
         PoolProperties poolProperties = new PoolProperties();
@@ -38,12 +38,12 @@ public class SchemaMigrationWarehouseTest {
     }
 
     @After
-    public void tearDown() throws Exception {
+    public void tearDown() {
         dataSource.close();
     }
 
     @Test
-    public void migrate() throws Exception {
+    public void migrate() {
         int result = schemaMigration.migrate();
         assertThat(result).isGreaterThan(0);
         //second migration will not change anything


### PR DESCRIPTION
Greg, i realized that we need a subject-specific place to specify the labels for the purposes and categories. I know that, in theory, the way i've done the categories isn't as flexible as it could be but i'm leaving it this way for now, let me know if you think we should change it. Specifically, i have `subject.ELA.trait.category.ORG` where i should probably have the purpose in there, something like `subject.ELA.trait.purpose.ARGU.category.ORG`. The reason i left it as is, is that i am imagining a fail-over approach: first look up the most specific label (`...trait.purpose.ARGU.category.ORG`) then fallback to a less specific label (`...trait.category.ORG`)